### PR TITLE
Make coverage reporting less of a nuisance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: 8c6794b6/hpc-codecov-action@v4
         with:
           target: cabal:interval-index-test
+          excludes: Test.*
       - name: Send coverage report
         uses: codecov/codecov-action@v4
         with:

--- a/coverage.yml
+++ b/coverage.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 70%
+    patch:
+      default:
+        target: auto
+        threshold: 80%

--- a/test/Test/Data/IntervalSpec.hs
+++ b/test/Test/Data/IntervalSpec.hs
@@ -2,8 +2,8 @@
 
 module Test.Data.IntervalSpec where
 
-import Data.Interval (Interval (..), IntervalLit (..), covers, touches)
 import Data.Foldable (traverse_)
+import Data.Interval (Interval (..), IntervalLit (..), covers, touches)
 import Test.Hspec (Spec, describe, it, shouldBe)
 
 spec :: Spec
@@ -39,7 +39,13 @@ spec = describe "intervals" $ do
             intervalWrapper4
             intervalWrapper5
           coversSuite "IntervalLit" intervalLit1 intervalLit2 intervalLit3 intervalLit4 intervalLit5
-          coversSuite "IntervalWrapper" intervalWrapper1 intervalWrapper2 intervalWrapper3 intervalWrapper4 intervalWrapper5
+          coversSuite
+            "IntervalWrapper"
+            intervalWrapper1
+            intervalWrapper2
+            intervalWrapper3
+            intervalWrapper4
+            intervalWrapper5
 
 newtype IntervalWrapper = IntervalWrapper (IntervalLit Char, String)
 


### PR DESCRIPTION
* configure codecov to chill out in the face of Pretty Good :tm: coverage
* configure `hpc` to exclude `Test` modules from coverage reporting

Closes #3 