### PR TITLE
Add benchmarks for merge and insert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ cabal.project.local~
 
 # from nix build
 result
+
+# from benchmarks
+bench-results

--- a/src/Data/Interval.hs
+++ b/src/Data/Interval.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE InstanceSigs #-}
@@ -63,14 +62,14 @@ data IntervalLit a = IntervalLit
 
 instance (NFData a) => NFData (IntervalLit a)
 
-ofInterval :: (Interval k a) => a -> IntervalLit k
-ofInterval x = IntervalLit (intervalStart x) (intervalEnd x)
-
-asEndpointVector :: IntervalLit a -> Vector.Vector a
-asEndpointVector (IntervalLit {start, end}) = Vector.fromList [start, end]
-
 instance (Ord a) => Interval a (IntervalLit a) where
   intervalStart :: IntervalLit a -> a
   intervalStart = start
   intervalEnd :: IntervalLit a -> a
   intervalEnd = end
+
+ofInterval :: (Interval k a) => a -> IntervalLit k
+ofInterval x = IntervalLit (intervalStart x) (intervalEnd x)
+
+asEndpointVector :: IntervalLit a -> Vector.Vector a
+asEndpointVector (IntervalLit {start, end}) = Vector.fromList [start, end]

--- a/src/Data/IntervalIndex.hs
+++ b/src/Data/IntervalIndex.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Data.IntervalIndex
@@ -13,10 +12,6 @@ module Data.IntervalIndex
     findCoveringInterval,
   )
 where
-
---   - merge is find keys that touch, split them up to find the new keys, but if present in only one of the two trees
---     leave it
---   - delete is find keys, remove from values (and maybe merge adjacent?)
 
 import Data.Containers.ListUtils (nubOrd)
 import Data.Foldable (fold, foldMap', foldl')


### PR DESCRIPTION
This PR:

* moves benchmark setup for `n` sample intervals to `env`
* adds benchmarks for `insert` / `merge` ops
* wraps all the benchmarks for a given input size list in a nice `benchN` function

Closes #10 